### PR TITLE
Update mongoDB schema to store referrers in sanitized format

### DIFF
--- a/blueprints/stats.py
+++ b/blueprints/stats.py
@@ -337,10 +337,13 @@ def export(short_code, format):
     url_data["password"] = url_data.get("password")
     url_data["last-click-browser"] = url_data.get("last-click-browser")
     url_data["last-click-os"] = url_data.get("last-click-os")
+    url_data["last-click-country"] = url_data.get("last-click-country")
+    url_data["last-click"] = url_data.get("last-click")
     url_data["block-bots"] = url_data.get("block-bots", False)
     url_data["bots"] = url_data.get("bots", {})
 
     url_data["counter"] = url_data.get("counter", {})
+    url_data["unique_counter"] = url_data.get("unique_counter", {})
     url_data["referrer"] = url_data.get("referrer", {})
     url_data["country"] = url_data.get("country", {})
     url_data["browser"] = url_data.get("browser", {})

--- a/blueprints/url_shortener.py
+++ b/blueprints/url_shortener.py
@@ -452,7 +452,7 @@ def redirect_url(short_code):
             if referrer_raw.suffix
             else referrer_raw.domain
         )
-        sanitized_referrer = referrer.replace(".", "_")
+        sanitized_referrer = re.sub(r"[.$\x00-\x1F\x7F-\x9F]", "_", referrer)
 
         updates["$inc"][f"referrer.{sanitized_referrer}.counts"] = 1
         updates["$addToSet"][f"referrer.{sanitized_referrer}.ips"] = user_ip


### PR DESCRIPTION
This PR fixes Issue #38

## Summary by Sourcery

Update the MongoDB schema to store referrers in a sanitized format by replacing dots with underscores in referrer keys. Remove the redundant initialization of referrer data in the URL shortener blueprint and use tldextract without caching for referrer extraction.

Bug Fixes:
- Fix the issue of storing referrers in an unsanitized format by replacing dots with underscores in referrer keys.

Enhancements:
- Use tldextract with no cache to extract referrer information.