### PR TITLE
Update stats-view.css

### DIFF
--- a/static/css/stats-view.css
+++ b/static/css/stats-view.css
@@ -136,10 +136,11 @@ select:hover {
 }
 
 #url_long_code {
-    max-width: 220px;
+    max-width: 70%;
     display: inline-flex;
-    overflow-x: scroll;
-    height: 28px;
+    overflow-x: auto;
+    min-height: 28px;
+    max-height: 50px;
 }
 
 #url_long_code::-webkit-scrollbar {

--- a/static/css/stats-view.css
+++ b/static/css/stats-view.css
@@ -138,9 +138,11 @@ select:hover {
 #url_long_code {
     max-width: 70%;
     display: inline-flex;
-    overflow-x: auto;
-    min-height: 28px;
-    max-height: 50px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 30px;
+    white-space: normal;
+    word-break: break-all;
 }
 
 #url_long_code::-webkit-scrollbar {
@@ -469,6 +471,10 @@ h3 {
     #analysisJson,
     #botsJson {
         height: 250px;
+    } */
+
+    /* #url_long_code {
+        max-width: 50%;
     } */
 
     #url_long_input {

--- a/templates/stats_view.html
+++ b/templates/stats_view.html
@@ -33,7 +33,7 @@
 
     <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/header.css') }}?v=3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/stats-view.css') }}?v=12">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/stats-view.css') }}?v=13">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile-header.css') }}?v=3">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/contacts-modal.css') }}?v=8">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/prism-duotone-dark.css') }}">


### PR DESCRIPTION
Better displays original url component when the url size is big.
**Before:**
-Vertical scroll
-less width
![IMG-20250505-WA0012](https://github.com/user-attachments/assets/de39535a-3ef9-4d4c-9f3b-51fd2a2ef9b7)
![IMG-20250505-WA0026](https://github.com/user-attachments/assets/407e4e9a-beee-4036-b8e7-4c96ff91d73a)
Notice how you dont even realise that it can be scrolled down to view the remaining url


**Now:**
-Horizontal scroll
-takes up more width of the container
![IMG-20250505-WA0015](https://github.com/user-attachments/assets/db266e9e-eb64-4018-9ed3-95cf58ac8afb)
![IMG-20250505-WA0013](https://github.com/user-attachments/assets/f1d119fc-39d4-4fa3-9946-bbbcb6b61e19)

## Summary by Sourcery

Improve the display of long URLs in the stats view by modifying the CSS to provide better visibility and scrolling

Enhancements:
- Modify URL display to use horizontal scrolling instead of vertical scrolling
- Increase the width of the URL container to 70% of available space
- Allow more flexible height for long URLs