### PR TITLE
Increase alias limit from 12 to 16 chars and minor api improvements

### DIFF
--- a/static/js/index-script.js
+++ b/static/js/index-script.js
@@ -5,12 +5,23 @@ function toggleDropdown() {
 
 const inputBox = document.querySelector('#alias');
 
+// Track if the alias notification has been shown
+let aliasNotificationShown = false;
+
 inputBox.addEventListener('focus', (e) => {
     document.querySelector('.buttonIn').classList.add('focus');
 });
 
 inputBox.addEventListener('blur', (e) => {
     document.querySelector('.buttonIn').classList.remove('focus');
+});
+
+inputBox.addEventListener('click', (e) => {
+    // Show the notification about 16-character limit only once per session
+    if (!aliasNotificationShown) {
+        customTopNotification("AliasUpdate", "✨ <b>New:</b> Custom aliases can now be up to <b>16 characters</b> long!", 10, "success");
+        aliasNotificationShown = true;
+    }
 });
 
 function get_metrics() {

--- a/templates/api.html
+++ b/templates/api.html
@@ -556,7 +556,7 @@ puts response.read_body</code></pre>
                     <td>400</td>
                     <td>The User requested Alias is invalid or already taken. The alias must be
                         <code>alphanumeric</code> & must
-                        be <code>under 15 chars</code>, anything beyond 15 chars would be stripped by the API
+                        be <code>under 17 chars (max-length: 16)</code>, anything beyond 16 chars would be stripped by the API
                     </td>
                 </tr>
                 <tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -237,7 +237,7 @@
                 </a>
             </div>
             <div class="discord-online">
-                <a id="discord-server-link" href="https://spoo.me/discord" target="_blank">
+                <a id="discord-server-link" href="https://spoo.me/discord" target="_blank" rel="noopener">
                     <h2 id="discord-online"></h2>
                     <h4>ONLINE IN DISCORD</h4>
                 </a>
@@ -257,7 +257,7 @@
 
     <script src="{{ url_for('static', filename='js/index-qrcode.js') }}"></script>
     <script src="{{ url_for('static', filename='js/index-validate.js') }}?v=1" defer=""></script>
-    <script src="{{ url_for('static', filename='js/index-script.js') }}?v=4" defer=""></script>
+    <script src="{{ url_for('static', filename='js/index-script.js') }}?v=5" defer=""></script>
     <script src="{{ url_for('static', filename='js/contacts-popup.js') }}?v=1" defer=""></script>
     <script src="{{ url_for('static', filename='js/header.js') }}?v=1" defer=""></script>
     <script src="{{ url_for('static', filename='js/self-promo.js') }}" defer=""></script>


### PR DESCRIPTION
## Summary by Sourcery

Increase the custom alias limit to 16 characters and enhance both API responses and stored metadata while removing the deprecated expiration-time feature.

New Features:
- Support custom aliases up to 16 characters (previously limited to 12) with a one-time UI notification.
- Include domain and original_url fields in JSON responses for newly created links.

Enhancements:
- Remove all expiration-time handling and related validation logic.
- Initialize stored URL records with creation date, time, client IP, click counters, and IP list.
- Add rel="noopener" to external links in templates and bump the main client script version to v5 for cache busting.

Documentation:
- Update API documentation to specify the new 16-character alias limit.